### PR TITLE
Change IFastEnumerator so that it enumerates over the DATA rather tha…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/opensquiggly/eugene.git</RepositoryUrl>
     <PackageProjectUrl>https://github.com/opensquiggly/eugene</PackageProjectUrl>
     <PackageTags>OpenSquiggly; Eugene; DataStructure; Data; Structure; Disk; Persistence; Persistent; Array; Arrays; LinkedList; LinkedLists; ArrayList; ArrayLists; Hash; HashTable; HashTables; Table; Tables; Binary; Tree; Trees; BinaryTree; BinaryTrees; BTree; BTrees; BPlusTree; BPlusTrees; TriTree; TrieTrees; Zoekt; Spinach; Popeye;</PackageTags>
-    <PackageVersion>1.0.1-alpha.25</PackageVersion>
+    <PackageVersion>1.0.1-alpha.26</PackageVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/source/Eugene/Collections/BTree/DiskBTree.cs
+++ b/source/Eugene/Collections/BTree/DiskBTree.cs
@@ -111,7 +111,7 @@ public class DiskBTree<TKey, TData> : IFastEnumerable<IFastEnumerator<TKey, TDat
     return RootNode.FindFirstGreaterThanOrEqual(key);
   }
 
-  public IEnumerator<TKey> GetEnumerator()
+  public IEnumerator<TData> GetEnumerator()
   {
     return new DiskBTreeCursor<TKey, TData>(this);
   }

--- a/source/Eugene/Collections/BTree/DiskBTreeCursor.cs
+++ b/source/Eugene/Collections/BTree/DiskBTreeCursor.cs
@@ -42,7 +42,7 @@ public class DiskBTreeCursor<TKey, TData> : IDictionaryCursor<TKey, TData>
 
   public DiskBTree<TKey, TData> BTree { get; private set; }
 
-  public TKey Current => CurrentKey;
+  public TData Current => CurrentData;
 
   object IEnumerator.Current => CurrentKey;
 

--- a/source/Eugene/Collections/SortedVarIntList/DiskSortedVarIntList.cs
+++ b/source/Eugene/Collections/SortedVarIntList/DiskSortedVarIntList.cs
@@ -167,7 +167,7 @@ public class DiskSortedVarIntList : IFastEnumerable<IFastEnumerator<ulong, long>
     return new DiskSortedVarIntListCursor(this);
   }
 
-  public IEnumerator<ulong> GetEnumerator()
+  public IEnumerator<long> GetEnumerator()
   {
     return new DiskSortedVarIntListCursor(this);
   }

--- a/source/Eugene/Collections/SortedVarIntList/DiskSortedVarIntListCursor.cs
+++ b/source/Eugene/Collections/SortedVarIntList/DiskSortedVarIntListCursor.cs
@@ -36,7 +36,7 @@ public class DiskSortedVarIntListCursor : IFastEnumerator<ulong, long>
   // Public Properties
   // /////////////////////////////////////////////////////////////////////////////////////////////
 
-  unsafe ulong IEnumerator<ulong>.Current => this.CurrentValue;
+  unsafe long IEnumerator<long>.Current => this.CurrentData;
 
   public object Current => this.CurrentValue;
 

--- a/source/Eugene/Enumerators/FastIntersectEnumerable.cs
+++ b/source/Eugene/Enumerators/FastIntersectEnumerable.cs
@@ -33,7 +33,7 @@ public class FastIntersectEnumerable<TKey, TData> : IFastIntersectEnumerable<TKe
     return new FastIntersectEnumerator<TKey, TData>(Enumerable1, Enumerable2);
   }
 
-  public IEnumerator<TKey> GetEnumerator()
+  public IEnumerator<TData> GetEnumerator()
   {
     return new FastIntersectEnumerator<TKey, TData>(Enumerable1, Enumerable2);
   }

--- a/source/Eugene/Enumerators/FastIntersectEnumerator.cs
+++ b/source/Eugene/Enumerators/FastIntersectEnumerator.cs
@@ -30,7 +30,7 @@ public class FastIntersectEnumerator<TKey, TData> : IFastIntersectEnumerator<TKe
   // Public Properties
   // /////////////////////////////////////////////////////////////////////////////////////////////
 
-  public TKey Current => CurrentKey;
+  public TData Current => CurrentData;
 
   public TKey CurrentKey => Enumerator1.CurrentKey;
 

--- a/source/Eugene/Enumerators/FastUnionEnumerable.cs
+++ b/source/Eugene/Enumerators/FastUnionEnumerable.cs
@@ -33,7 +33,7 @@ public class FastUnionEnumerable<TKey, TData> : IFastUnionEnumerable<TKey, TData
     return new FastUnionEnumerator<TKey, TData>(Enumerable1, Enumerable2);
   }
 
-  public IEnumerator<TKey> GetEnumerator()
+  public IEnumerator<TData> GetEnumerator()
   {
     return new FastUnionEnumerator<TKey, TData>(Enumerable1, Enumerable2);
   }

--- a/source/Eugene/Enumerators/FastUnionEnumerator.cs
+++ b/source/Eugene/Enumerators/FastUnionEnumerator.cs
@@ -39,7 +39,7 @@ public class FastUnionEnumerator<TKey, TData> : IFastUnionEnumerator<TKey, TData
   // Public Properties
   // /////////////////////////////////////////////////////////////////////////////////////////////
 
-  public TKey Current => CurrentKey;
+  public TData Current => CurrentData;
 
   public TKey CurrentKey => CurrentEnumerator.CurrentKey;
 

--- a/source/Eugene/Enumerators/IFastEnumerable.cs
+++ b/source/Eugene/Enumerators/IFastEnumerable.cs
@@ -1,6 +1,6 @@
 namespace Eugene.Enumerators;
 
-public interface IFastEnumerable<TResult, TKey, TData> : IEnumerable<TKey>
+public interface IFastEnumerable<TResult, TKey, TData> : IEnumerable<TData>
   where TKey : IComparable<TKey>
   where TResult : IFastEnumerator<TKey, TData>
 {

--- a/source/Eugene/Enumerators/IFastEnumerator.cs
+++ b/source/Eugene/Enumerators/IFastEnumerator.cs
@@ -1,6 +1,6 @@
 namespace Eugene.Enumerators;
 
-public interface IFastEnumerator<TKey, TData> : IEnumerator<TKey> where TKey : IComparable<TKey>
+public interface IFastEnumerator<TKey, TData> : IEnumerator<TData> where TKey : IComparable<TKey>
 {
   public TKey CurrentKey { get; }
   public TData CurrentData { get; }


### PR DESCRIPTION
…n the KEY (implements IEnumerator<TData> instead of IEnumerator<TKey>)

An IFastEnumerator is an enumerator that can skip ahead in the data structure more quickly, using a key and the MoveUntilGreaterThanOrEqual() method.

So it skips ahead by KEYS. But the thing it actually returns, it makes more sense to think of it as enumerating over the DATA. The data is the actual thing you want. The keys are how you traverse the structure, but the data is what you are after, so therefore IEnumerator<TData> makes more sense intuitively. The logic of the enumerator doesn't change. It's just a question of what type do you want the "Current" property to return.